### PR TITLE
Add power select in focussable elements collection

### DIFF
--- a/packages/modal/addon/constants/nucleus-modal.js
+++ b/packages/modal/addon/constants/nucleus-modal.js
@@ -1,3 +1,3 @@
-const focusableElements = 'a[href]:not([disabled]), button:not([disabled]), textarea:not([disabled]), input[type="text"]:not([disabled]), input[type="radio"]:not([disabled]), input[type="checkbox"]:not([disabled]), select:not([disabled])';
+const focusableElements = 'a[href]:not([disabled]), button:not([disabled]), textarea:not([disabled]), input[type="text"]:not([disabled]), input[type="radio"]:not([disabled]), input[type="checkbox"]:not([disabled]), select:not([disabled]), .ember-power-select-trigger:not([aria-disabled=true]';
 
 export { focusableElements };


### PR DESCRIPTION
#### Description

Focus not moving to successive select fields on tab click

#### Issue Reason

Select2 is not added in the focussable list

#### Issue Fix

Updated the focussable list inside `constants/nucleus-modal.js`

Ticket: [FC-90532](https://freshworks.freshrelease.com/ws/FC/tasks/FC-90532)